### PR TITLE
Widged refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# vendor dirs
+vendor
+
+# composer lock files
+composer.lock
+
+# IDE & OS files
+.*.swp
+.idea
+nbproject
+.buildpath
+.project
+.settings
+Thumbs.db
+.DS_Store

--- a/DateRangePicker.php
+++ b/DateRangePicker.php
@@ -64,6 +64,11 @@ class DateRangePicker extends InputWidget
      *  - `tag`: the tag name, defaults to input
      */
     public $options = [];
+    /**
+     * @var JsExpression the callback that will be passed to the JS plugin call as a second argument
+     * @see http://www.daterangepicker.com/#ex3
+     */
+    public $callback;
 
     public function init()
     {
@@ -79,7 +84,7 @@ class DateRangePicker extends InputWidget
 
     public function run()
     {
-        echo $this->renderWidget() . "\n";
+        echo $this->renderInput() . "\n";
 
         $this->setupRanges();
         $this->localize();
@@ -106,24 +111,22 @@ class DateRangePicker extends InputWidget
         }
     }
 
-    protected function renderWidget()
+    /**
+     * @return string
+     */
+    protected function renderInput()
     {
-        if ($this->hasModel()) {
-            $value = Html::getAttributeValue($this->model, $this->attribute);
-        } else {
-            $value = $this->value;
-        }
-
         $options = $this->options;
-        $options['value'] = $value;
 
-        if ($this->hasModel()) {
-            $contents[] = Html::activeTextInput($this->model, $this->attribute, $options);
-        } else {
-            $contents[] = Html::textInput($this->name, $value, $options);
+        if (isset($options['tag']) && $options['tag'] === false) {
+            return '';
         }
 
-        return implode("\n", $contents);
+        if ($this->hasModel()) {
+            return Html::activeTextInput($this->model, $this->attribute, $options);
+        } else {
+            return Html::textInput($this->name, $this->value, $options);
+        }
     }
 
     /**
@@ -235,6 +238,11 @@ class DateRangePicker extends InputWidget
             'separator' => $this->separator,
         ], $this->clientOptions);
 
-        $this->view->registerJs("$('#$id').daterangepicker(" . Json::encode($options) . )
+        $arguments = [Json::encode($options)];
+        if ($this->callback !== null) {
+            $arguments[] = $this->callback;
+        }
+
+        $this->view->registerJs("$('#$id').daterangepicker(" . implode(',', $arguments) . ');');
     }
 }

--- a/DateRangePicker.php
+++ b/DateRangePicker.php
@@ -64,11 +64,6 @@ class DateRangePicker extends InputWidget
      *  - `tag`: the tag name, defaults to input
      */
     public $options = [];
-    /**
-     * @var JsExpression the callback that will be passed to the JS plugin call as a second argument
-     * @see http://www.daterangepicker.com/#ex3
-     */
-    public $callback;
 
     public function init()
     {
@@ -238,11 +233,14 @@ class DateRangePicker extends InputWidget
             'separator' => $this->separator,
         ], $this->clientOptions);
 
-        $arguments = [Json::encode($options)];
-        if ($this->callback !== null) {
-            $arguments[] = $this->callback;
-        }
+        $this->getView()->registerJs("$('#$id').daterangepicker(" . Json::encode($options) . ');');
 
-        $this->view->registerJs("$('#$id').daterangepicker(" . implode(',', $arguments) . ');');
+        if ($this->clientEvents) {
+            $js = "$('#$id')";
+            foreach ($this->clientEvents as $event => $handler) {
+                $js .= ".on('$event', $handler)";
+            }
+            $this->getView()->registerJs($js . ';');
+        }
     }
 }

--- a/DateRangePicker.php
+++ b/DateRangePicker.php
@@ -61,7 +61,8 @@ class DateRangePicker extends InputWidget
     /**
      * @inheritdoc
      * The following options are specially handled:
-     *  - `tag`: the tag name, defaults to input
+     *  - `tag`: the tag name. Set to `false` in order to prevent input render. When the property is not set, widget
+     * will render the `<input>` tag.
      */
     public $options = [];
 
@@ -113,14 +114,20 @@ class DateRangePicker extends InputWidget
     {
         $options = $this->options;
 
-        if (isset($options['tag']) && $options['tag'] === false) {
-            return '';
-        }
+        if (isset($options['tag'])) {
+            if ($options['tag'] === false) {
+                return '';
+            }
 
-        if ($this->hasModel()) {
-            return Html::activeTextInput($this->model, $this->attribute, $options);
+            $tag = ArrayHelper::remove($options, 'tag');
+            $value = $this->hasModel() ? Html::getAttributeValue($this->model, $this->attribute) : $this->value;
+            return Html::tag($tag, $value, $options);
         } else {
-            return Html::textInput($this->name, $this->value, $options);
+            if ($this->hasModel()) {
+                return Html::activeTextInput($this->model, $this->attribute, $options);
+            } else {
+                return Html::textInput($this->name, $this->value, $options);
+            }
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "range",
     "picker"
   ],
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "authors": [
     {
       "name": "Pavel Agalecky",


### PR DESCRIPTION
This PR offers the following enhancements:
- Adds `.gitignore`
- Changes `minimum-stability` to `stable
- Separates `run()` method into more specific `registerAssets()` and `registerClientScript()` methods in order to offer a possibility of partial logic overriding
- Setting `DateRangePicker::options['tag']` will affect the `renderInput()` (see PHPDoc of $options)
